### PR TITLE
Remove deprecation warning about new PropTypes package

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "eslint-loader": "^1.3.0",
     "eslint-plugin-react": "^4.2.3",
     "eslint-watch": "^2.1.10",
+    "prop-types": "^15.6.0",
     "raw-loader": "^0.5.1",
     "react": "^0.14.7",
     "react-dom": "^0.14.7",
@@ -57,5 +58,6 @@
     "lint": "esw -w src/* demo/index.js",
     "test": "echo \"Comming soon ;)\" && exit 0"
   },
-  "dependencies": {}
+  "dependencies": {
+  }
 }

--- a/src/ReactSwiper.js
+++ b/src/ReactSwiper.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Swiper from 'swiper';
 
 function pagination(argPagination) {
@@ -198,10 +199,10 @@ class ReactSwiper extends React.Component {
 
 if (process.env.NODE_ENV !== 'production') {
   ReactSwiper.propTypes = {
-    children: React.PropTypes.any.isRequired,
-    swipeOptions: React.PropTypes.object,
-    style: React.PropTypes.object,
-    className: React.PropTypes.string,
+    children: PropTypes.any.isRequired,
+    swipeOptions: PropTypes.object,
+    style: PropTypes.object,
+    className: PropTypes.string,
   };
 }
 


### PR DESCRIPTION
This is needed to be ready for React 16.